### PR TITLE
The need for MobileTwigModule has decreased, so we will make it an optional install

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,6 +1,6 @@
 {
   "symbol-whitelist" : [
-    "Mobile_Detect"
+    "Mobile_Detect", "Detection\\MobileDetect"
   ],
   "php-core-extensions" : [
     "Core",

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "bear/sunday": "^1.7",
     "bear/app-meta": "^1.8",
     "twig/twig": "^v3.15",
-    "mobiledetect/mobiledetectlib": "^3.74.3",
     "ray/di": "^2.17",
     "ray/aop": "^2.17",
     "psr/log": "^3.0.2"
   },
   "require-dev": {
+    "mobiledetect/mobiledetectlib": "^3.74.3",
     "phpunit/phpunit": "^9.6.21",
     "doctrine/annotations": "^1.14.4 || ^2.0",
     "bamarni/composer-bin-plugin": "^1.8.2"
@@ -66,5 +66,8 @@
       "bin-links": true,
       "forward-command": true
     }
+  },
+  "suggest": {
+    "mobiledetect/mobiledetectlib": "MobileTwigModule"
   }
 }

--- a/src/MobileTwigModule.php
+++ b/src/MobileTwigModule.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Madapaja\TwigModule;
 
+use Detection\MobileDetect;
 use Ray\Di\AbstractModule;
+use RuntimeException;
+
+use function class_exists;
 
 /**
  * Provides TemplateFinderInterface and derived bindings
@@ -17,6 +21,15 @@ use Ray\Di\AbstractModule;
  */
 class MobileTwigModule extends AbstractModule
 {
+    public function __construct(AbstractModule $module)
+    {
+        if (! class_exists(MobileDetect::class)) {
+            throw new RuntimeException('mobiledetect/mobiledetectlib is required for MobileTwigModule, please install it via composer. (composer require mobiledetect/mobiledetectlib)'); // @codeCoverageIgnore
+        }
+
+        parent::__construct($module);
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
See https://github.com/madapaja/Madapaja.TwigModule/releases/tag/2.6.0

In order to use the MobileTwigModule, it is necessary to install mobiledetect/mobiledetectlib. Relocate `mobiledetect/mobiledetectlib` to "require-dev" in composer.json and implement a runtime check that throws an exception if the dependency is missing in MobileTwigModule. Additionally, add getInput method to ErrorPagerRenderer to handle input values from resource objects.