### PR TITLE
Add Psalm taint annotations for XSS prevention

### DIFF
--- a/src/ErrorPagerRenderer.php
+++ b/src/ErrorPagerRenderer.php
@@ -28,6 +28,8 @@ class ErrorPagerRenderer implements RenderInterface
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
+     *
+     * @psalm-taint-escape html
      */
     public function render(ResourceObject $ro): string
     {

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -41,6 +41,8 @@ class TwigRenderer implements RenderInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-taint-escape html
      */
     public function render(ResourceObject $ro)
     {


### PR DESCRIPTION
## Summary

Add Psalm taint annotations to mark Twig rendering as HTML-safe (due to Twig's autoescape feature).

## Changes

- `@psalm-taint-escape html` on:
  - `TwigRenderer::render()` - Twig autoescapes by default
  - `ErrorPagerRenderer::render()` - Error page rendering

This allows Psalm's taint analysis to understand that data passing through Twig templates is properly escaped for HTML output.

## Test Plan

- [ ] Run `./vendor/bin/psalm --taint-analysis` to verify annotations work
- [ ] Existing tests pass