### PR TITLE
Modify export-ignore entries in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,18 @@
 # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitattributes.html
+/.github            export-ignore
 /tests              export-ignore
+/vendor-bin         export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.scrutinizer.yml   export-ignore
+/.php_cs            export-ignore
+/codecov.yml        export-ignore
+/composer-require-checker.json export-ignore
 /phpcs.xml          export-ignore
 /phpmd.xml          export-ignore
 /phpstan.neon       export-ignore
 /phpunit.xml.dist   export-ignore
 /psalm.xml          export-ignore
+/rector.php         export-ignore
 
 *.php diff=php
 *.phar -diff


### PR DESCRIPTION
Updated export-ignore rules in .gitattributes to include additional configuration files.

With this PR, the archive targets other than src/ will be as follows:

```
gh api repos/sasezaki/Madapaja.TwigModule/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
composer.json
var/
var/templates/
var/templates/Page/
var/templates/Page/Index.html.twig
var/templates/error/
var/templates/error/error.html.twig
var/templates/layout/
var/templates/layout/base.html.twig
var/templates/redirect/
var/templates/redirect/redirect.html.twig
```